### PR TITLE
DemuxWriter allocate + commit, to allocate messages directly in the buffer and allow zero-copy

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -62,9 +62,13 @@ jobs:
         working-directory: ${{github.workspace}}
         run: cmake --build ./build --target test
 
-      - name: Run Example
+      - name: Run Example zero_copy=false
         working-directory: ${{github.workspace}}
-        run: ./bin/run-example.sh
+        run: ./bin/run-example.sh 10000000 false
+
+      - name: Run Example zero_copy=true
+        working-directory: ${{github.workspace}}
+        run: ./bin/run-example.sh 10000000 true
 
       - name: Run clang-tidy Checks
         working-directory: ${{github.workspace}}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
   "cSpell.words": [
     "bipc",
     "Demultiplexer",
+    "initializable",
     "Interprocess",
     "lshl",
     "NOLINTNEXTLINE",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ target_link_libraries(
   reader_id
   hdr_histogram::hdr_histogram_static
   Boost::log
-  profiler
+  # profiler
 )
 target_compile_options(
   shm_demux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON) # generate a compile_commands.json file, n
 set(MY_CXX_FLAGS -Wall -Wextra -Wshadow -Wnon-virtual-dtor -pedantic -Wconversion -Wsign-conversion -Werror)
 
 set(CMAKE_CXX_FLAGS_DEBUG "-gdwarf-4 -O0") # valgrind needs `-gdwarf-4`
-#set(CMAKE_CXX_FLAGS_DEBUG "-gdwarf-4 -O3 -DNDEBUG") # `-03 -DNDEBUG` for gperftools
+#set(CMAKE_CXX_FLAGS_DEBUG "-g -gdwarf-4 -O3 -DNDEBUG") # `-03 -DNDEBUG` for gperftools
 
 # default settins for other build types:
 # set(CMAKE_CXX_FLAGS_RELEASE "-O3")
@@ -95,7 +95,7 @@ target_link_libraries(
   reader_id
   hdr_histogram::hdr_histogram_static
   Boost::log
-  #profiler
+  profiler
 )
 target_compile_options(
   shm_demux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,25 @@ target_compile_options(
 gtest_discover_tests(demultiplexer_test)
 
 add_executable(
+  demultiplexer_allocate_test
+  src/demux/test/demultiplexer_allocate_test.cpp
+)
+target_link_libraries(
+  demultiplexer_allocate_test
+  demultiplexer
+  reader_id
+  gtest::gtest
+  rapidcheck::rapidcheck
+  Boost::log
+  atomic
+)
+target_compile_options(
+  demultiplexer_allocate_test
+  PRIVATE ${MY_CXX_FLAGS}
+)
+gtest_discover_tests(demultiplexer_allocate_test)
+
+add_executable(
   shm_util_test
   src/demux/test/shm_util_test.cpp
 )

--- a/README.md
+++ b/README.md
@@ -91,10 +91,26 @@ $ ./bin/release.sh
 
 ## 7. Run Tests
 
-Execute tests using the following command:
+### 7.1. Run All Tests
+
+Execute all tests using cmake:
 
 ```
 $ cmake --build ./build --target test
+```
+
+### 7.2. Run One Test
+
+Execute "SlowReader" test using ctest:
+
+```
+$ ctest --test-dir ./build -R SlowReader -V
+```
+
+Execute "SlowReader" test using main function:
+
+```
+$ ./build/demultiplexer_test --gtest_filter=*SlowReader
 ```
 
 ## 8. Run Example

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ $ ./bin/run-example.sh
 ### 11.4. Generate the profiling report
 
 ```
-$ google-pprof --text ./build/shm_demux ./shm_demux_pub.prof &> pprof-report.out
+$ google-pprof --text ./build/shm_demux ./shm_demux_writer.prof &> pprof-report.out
 ```
 
 ## 12. Conan Commands

--- a/bin/run-example.sh
+++ b/bin/run-example.sh
@@ -13,13 +13,12 @@ __root="$(cd "$(dirname "${__dir}")" && pwd)"
 cd "${__root}"
 
 msg_num=${1:-10000000}
-zero_copy=${2:-"false"}
+zero_copy=${2:-"true"}
 
 #valgrind_cmd="valgrind --tool=memcheck --leak-check=full --show-leak-kinds=all --track-origins=yes --trace-children=yes --track-fds=yes --log-file=valgrind.out"
 
-#CPUPROFILE=shm_demux_writer.prof
-
 # start writer expecting 2 readers
+#CPUPROFILE=shm_demux_writer.prof CPUPROFILE_FREQUENCY=1000 \
 ./build/shm_demux writer 2 "${msg_num}" "${zero_copy}" > ./example-writer.out 2>&1 &
 writer_pid="$!"
 
@@ -64,3 +63,6 @@ else
   echo "Found unequals hash codes: " "${hash_codes[@]}"
   exit 100
 fi
+
+# generate profiler report
+#google-pprof --text ./build/shm_demux ./shm_demux_writer.prof &> pprof-report.out

--- a/bin/run-example.sh
+++ b/bin/run-example.sh
@@ -13,7 +13,7 @@ __root="$(cd "$(dirname "${__dir}")" && pwd)"
 cd "${__root}"
 
 msg_num=${1:-10000000}
-zero_copy=${2:-"true"}
+zero_copy=${2:-"false"}
 
 #valgrind_cmd="valgrind --tool=memcheck --leak-check=full --show-leak-kinds=all --track-origins=yes --trace-children=yes --track-fds=yes --log-file=valgrind.out"
 

--- a/bin/run-example.sh
+++ b/bin/run-example.sh
@@ -13,13 +13,14 @@ __root="$(cd "$(dirname "${__dir}")" && pwd)"
 cd "${__root}"
 
 msg_num=${1:-10000000}
+zero_copy=${2:-"false"}
 
 #valgrind_cmd="valgrind --tool=memcheck --leak-check=full --show-leak-kinds=all --track-origins=yes --trace-children=yes --track-fds=yes --log-file=valgrind.out"
 
 #CPUPROFILE=shm_demux_writer.prof
 
 # start writer expecting 2 readers
-./build/shm_demux writer 2 "${msg_num}" > ./example-writer.out 2>&1 &
+./build/shm_demux writer 2 "${msg_num}" "${zero_copy}" > ./example-writer.out 2>&1 &
 writer_pid="$!"
 
 # let the writer start and initialize all shared memory objects, it will wait for both readers
@@ -27,8 +28,8 @@ sleep 2s
 
 # start 2 readers
 
-./build/shm_demux reader 1 "${msg_num}" &> ./example-reader-1.out &
-./build/shm_demux reader 2 "${msg_num}" &> ./example-reader-2.out &
+./build/shm_demux reader 1 "${msg_num}" "${zero_copy}" &> ./example-reader-1.out &
+./build/shm_demux reader 2 "${msg_num}" "${zero_copy}" &> ./example-reader-2.out &
 
 # report the state
 #ps -ef|grep -F "./build/shm_demux"

--- a/src/demux/core/demultiplexer.h
+++ b/src/demux/core/demultiplexer.h
@@ -172,13 +172,13 @@ class DemuxWriter {
   /// @return std::optional<A*> -- pointer to allocated message or `null_opt` if error happened.
   template <class A>
     requires(std::default_initializable<A> && sizeof(A) != 0 && sizeof(A) <= M)
-  [[nodiscard]] auto allocate_blocking(uint8_t recursion_level) noexcept -> std::optional<A*>;
+  [[nodiscard]] inline auto allocate_blocking(uint8_t recursion_level) noexcept -> std::optional<A*>;
 
   /// @brief does not block while waiting for readers to catch up, returns `std::null_opt` instead.
   /// @return `std::optional<A*>` -- pointer to allocated message or `null_opt` if there is no space left in the buffer.
   template <class A>
     requires(std::default_initializable<A> && sizeof(A) != 0 && sizeof(A) <= M)
-  [[nodiscard]] auto allocate_non_blocking() noexcept -> std::optional<A*>;
+  [[nodiscard]] inline auto allocate_non_blocking() noexcept -> std::optional<A*>;
 
   auto wait_for_readers_to_catch_up_and_wraparound() noexcept -> void;
 
@@ -340,7 +340,8 @@ template <size_t L, uint16_t M, bool B>
   requires(L >= M + 2 && M > 0)
 template <class A>
   requires(std::default_initializable<A> && sizeof(A) != 0 && sizeof(A) <= M)
-[[nodiscard]] auto DemuxWriter<L, M, B>::allocate_blocking(uint8_t recursion_level) noexcept -> std::optional<A*> {
+[[nodiscard]] inline auto DemuxWriter<L, M, B>::allocate_blocking(uint8_t recursion_level
+) noexcept -> std::optional<A*> {
   std::optional<A*> result = this->buffer_.template allocate<A>(this->position_);
   if (result.has_value()) {
     return result;
@@ -359,7 +360,7 @@ template <size_t L, uint16_t M, bool B>
   requires(L >= M + 2 && M > 0)
 template <class A>
   requires(std::default_initializable<A> && sizeof(A) != 0 && sizeof(A) <= M)
-[[nodiscard]] auto DemuxWriter<L, M, B>::allocate_non_blocking() noexcept -> std::optional<A*> {
+[[nodiscard]] inline auto DemuxWriter<L, M, B>::allocate_non_blocking() noexcept -> std::optional<A*> {
   if (this->wraparound_) {
     if (this->all_readers_caught_up()) {
       this->complete_wraparound();

--- a/src/demux/core/demultiplexer.h
+++ b/src/demux/core/demultiplexer.h
@@ -98,6 +98,18 @@ class DemuxWriter {
     return this->write_safe<X>(raw);
   }
 
+  template <class A>
+    requires(sizeof(A) <= M)
+  [[nodiscard]] auto allocate_object() -> std::optional<A*> {
+    return this->buffer_.template allocate<A>(this->position_);
+  }
+
+  auto commit() -> WriteResult {
+    // TODO(Leo): increment message_count to notify that new message is allocated and available for the reader to read
+    // TODO(Leo): write a test for allocate + commit
+    return Error;
+  }
+
   /// @brief does not check the size of the `span`, it is checked at compiles time, see the `requires` clause.
   /// @tparam `N` the message size.
   /// @param `source` message that will be copied into the circular buffer.

--- a/src/demux/core/message_buffer.h
+++ b/src/demux/core/message_buffer.h
@@ -63,7 +63,7 @@ struct MessageBuffer {
   /// @param position -- the zero-based byte offset at which the message should be allocated in the buffer.
   /// @return std::optional<A*> none when message could not be allocated because there is not enough space.
   template <class A>
-    requires std::default_initializable<A>
+    requires(std::default_initializable<A> && sizeof(message_length_t) + sizeof(A) <= L)
   [[nodiscard]] auto allocate(const size_t position) -> std::optional<A*> {
     constexpr size_t x = sizeof(message_length_t);
     constexpr size_t n = sizeof(A);

--- a/src/demux/core/message_buffer.h
+++ b/src/demux/core/message_buffer.h
@@ -114,6 +114,22 @@ struct MessageBuffer {
     }
   }
 
+  /// @brief Reads a message at the specified position and `reinterpret_cast`s it to the specified type.
+  /// @tparam A -- type of the object.
+  /// @param position -- the zero-based byte offset at which the message should be allocated in the buffer.
+  /// @return std::optional<A*> none when message could not be read because there is not enough space.
+  template <class A>
+    requires(std::default_initializable<A> && sizeof(message_length_t) + sizeof(A) <= L)
+  [[nodiscard]] auto read_unsafe(const size_t position) const noexcept -> std::optional<const A*> {
+    span<uint8_t> raw = this->read(position);
+    if (raw.empty()) {
+      return std::nullopt;
+    } else {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast,cppcoreguidelines-pro-type-const-cast, modernize-use-auto)
+      return reinterpret_cast<A*>(raw.data());
+    }
+  }
+
  private:
   uint8_t* data_;
 };

--- a/src/demux/core/message_buffer.h
+++ b/src/demux/core/message_buffer.h
@@ -8,6 +8,7 @@
 #include <concepts>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <optional>
 #include <span>
 
@@ -54,6 +55,7 @@ struct MessageBuffer {
   /// @tparam A -- type of the message.
   /// @return total space in the buffer required fo allocating an object of type A in the buffer.
   template <class A>
+    requires(sizeof(A) <= std::numeric_limits<message_length_t>::max())
   [[nodiscard]] static constexpr auto required() -> std::size_t {
     return sizeof(message_length_t) + sizeof(A);
   }
@@ -63,7 +65,8 @@ struct MessageBuffer {
   /// @param position -- the zero-based byte offset at which the message should be allocated in the buffer.
   /// @return std::optional<A*> none when message could not be allocated because there is not enough space.
   template <class A>
-    requires(std::default_initializable<A> && sizeof(message_length_t) + sizeof(A) <= L)
+    requires(std::default_initializable<A> && sizeof(A) <= std::numeric_limits<message_length_t>::max() &&
+             sizeof(message_length_t) + sizeof(A) <= L)
   [[nodiscard]] auto allocate(const size_t position) -> std::optional<A*> {
     constexpr size_t x = sizeof(message_length_t);
     constexpr size_t n = sizeof(A);

--- a/src/demux/example/shm_demux.cpp
+++ b/src/demux/example/shm_demux.cpp
@@ -37,13 +37,14 @@
 #include "./market_data.h"
 
 auto print_usage(const char* prog) -> void {
-  std::cerr << "Usage: " << prog << " [writer <number-of-readers> <number-of-messages>] "
-            << " | [reader <unique-reader-number> <number-of-messages>]\n"
+  std::cerr << "Usage: " << prog << " [writer <number-of-readers> <number-of-messages> <zero-copy>]"
+            << " | [reader <unique-reader-number> <number-of-messages> <zero-copy>]\n"
             << "  where\n"
             << "    <number-of-readers> and <unique-reader-number> are within the interval [1, "
             << static_cast<int>(lshl::demux::core::MAX_READER_NUM) << "]\n"
             << "    <number-of-messages> is within the interval [1, " << std::numeric_limits<uint64_t>::max()
-            << "] (uint64_t)\n";
+            << "] (uint64_t)\n"
+            << "    <zero-copy> true/false\n";
 }
 
 auto main(int argc, char* argv[]) noexcept -> int {
@@ -96,10 +97,11 @@ using std::uint16_t;
 
 auto main_(const span<char*> args) noexcept(false) -> int {
   constexpr int ERROR = 200;
+  constexpr size_t EXPECTED_ARG_NUM = 5;
 
   init_logging();
 
-  if (args.size() != 4) {
+  if (args.size() != EXPECTED_ARG_NUM) {
     print_usage(args[0]);
     return ERROR;
   }
@@ -112,9 +114,10 @@ auto main_(const span<char*> args) noexcept(false) -> int {
   }
   const auto num8 = static_cast<uint8_t>(num16);
   const auto msg_num = boost::lexical_cast<uint64_t>(args[3]);
+  const auto zero_copy = std::string("true") == args[4];
 
   if (command == "writer") {
-    start_writer<BUFFER_SIZE, MAX_MESSAGE_SIZE>(num8, msg_num);
+    start_writer<BUFFER_SIZE, MAX_MESSAGE_SIZE>(num8, msg_num, zero_copy);
   } else if (command == "reader") {
     start_reader<BUFFER_SIZE, MAX_MESSAGE_SIZE>(num8, msg_num);
   } else {
@@ -130,18 +133,19 @@ auto init_logging() noexcept -> void {
 }
 
 template <size_t L, uint16_t M>
-auto start_writer(const uint8_t total_reader_num, const uint64_t msg_num) noexcept(false) -> void {
+auto start_writer(const uint8_t total_reader_num, const uint64_t msg_num, bool zero_copy) noexcept(false) -> void {
   const size_t SHM_SIZE = lshl::demux::util::calculate_required_shared_mem_size(
       L, lshl::demux::util::BOOST_IPC_INTERNAL_METADATA_SIZE, lshl::demux::util::LINUX_PAGE_SIZE
   );
 
   BOOST_LOG_TRIVIAL(info) << "start_writer " << BUFFER_SHARED_MEM_NAME << ", size: " << SHM_SIZE << ", L: " << L
-                          << ", M: " << M << ", total_reader_num: " << static_cast<int>(total_reader_num);
+                          << ", M: " << M << ", total_reader_num: " << static_cast<int>(total_reader_num)
+                          << ", zero_copy: " << zero_copy;
 
   const ShmRemover remover1(BUFFER_SHARED_MEM_NAME);
   const ShmRemover remover2(UTIL_SHARED_MEM_NAME);
 
-  const uint64_t all_subs_mask = ReaderId::all_readers_mask(total_reader_num);
+  const uint64_t all_readers_mask = ReaderId::all_readers_mask(total_reader_num);
 
   // segment for the circular buffer and message counter, written by writer, read by readers
   bipc::managed_shared_memory segment1(bipc::create_only, BUFFER_SHARED_MEM_NAME, SHM_SIZE);
@@ -165,14 +169,16 @@ auto start_writer(const uint8_t total_reader_num, const uint64_t msg_num) noexce
   atomic<uint64_t>* startup_sync = segment2.construct<atomic<uint64_t>>("startup_sync")(0);
   BOOST_LOG_TRIVIAL(info) << "startup_sync allocated, segment2.free_memory: " << segment2.get_free_memory();
 
-  lshl::demux::core::DemuxWriter<L, M, false> pub(all_subs_mask, span{*buffer}, message_count_sync, wraparound_sync);
+  lshl::demux::core::DemuxWriter<L, M, false> writer(
+      all_readers_mask, span{*buffer}, message_count_sync, wraparound_sync
+  );
   BOOST_LOG_TRIVIAL(info) << "DemuxWriter created, segment1.free_memory: " << segment1.get_free_memory()
                           << ", segment2.free_memory: " << segment2.get_free_memory();
 
   BOOST_LOG_TRIVIAL(info) << "waiting for all readers ...";
   while (true) {
     const uint64_t x = startup_sync->load();
-    if (x == all_subs_mask) {
+    if (x == all_readers_mask) {
       break;
     } else {
       using namespace std::chrono_literals;
@@ -181,13 +187,18 @@ auto start_writer(const uint8_t total_reader_num, const uint64_t msg_num) noexce
   }
   BOOST_LOG_TRIVIAL(info) << "all readers connected";
 
-  run_writer_loop(pub, msg_num);
+  if (zero_copy) {
+    run_writer_loop_zero_copy(writer, msg_num);
+  } else {
+    run_writer_loop(writer, msg_num);
+  }
   BOOST_LOG_TRIVIAL(info) << "DemuxWriter completed, segment1.free_memory: " << segment1.get_free_memory()
                           << ", segment2.free_memory: " << segment2.get_free_memory();
 }
 
 template <size_t L, uint16_t M>
-auto run_writer_loop(lshl::demux::core::DemuxWriter<L, M, false>& pub, const uint64_t msg_num) noexcept(false) -> void {
+auto run_writer_loop(lshl::demux::core::DemuxWriter<L, M, false>& writer, const uint64_t msg_num) noexcept(false
+) -> void {
   BOOST_LOG_TRIVIAL(info) << "sending " << msg_num << " md updates ...";
 
   MarketDataUpdate md{};
@@ -199,7 +210,7 @@ auto run_writer_loop(lshl::demux::core::DemuxWriter<L, M, false>& pub, const uin
 #ifndef NDEBUG
     BOOST_LOG_TRIVIAL(debug) << md;
 #endif
-    const bool ok = send_(pub, md);
+    const bool ok = write_(writer, md);
     if (!ok) {
       BOOST_LOG_TRIVIAL(error) << "dropping message, could not write: " << md;
       continue;
@@ -210,15 +221,15 @@ auto run_writer_loop(lshl::demux::core::DemuxWriter<L, M, false>& pub, const uin
     hash.update(&md, sizeof(MarketDataUpdate));
   }
 
-  BOOST_LOG_TRIVIAL(info) << "writer sequence number: " << pub.message_count()
+  BOOST_LOG_TRIVIAL(info) << "writer sequence number: " << writer.message_count()
                           << ", XXH64_hash: " << XXH64_util::format(hash.digest());
 }
 
 template <class T, size_t L, uint16_t M>
-[[nodiscard]] inline auto send_(DemuxWriter<L, M, false>& pub, const T& md) noexcept -> bool {
+[[nodiscard]] inline auto write_(DemuxWriter<L, M, false>& writer, const T& md) noexcept -> bool {
   int attempt = 0;
   while (true) {
-    const WriteResult result = pub.write_safe(md);
+    const WriteResult result = writer.write_safe(md);
     switch (result) {
       case WriteResult::Success:
         return true;
@@ -228,9 +239,58 @@ template <class T, size_t L, uint16_t M>
         attempt += 1;
         if (attempt % REPORT_PROGRESS == 0) {
           BOOST_LOG_TRIVIAL(warning) << "one or more readers are lagging, wraparound is blocked, write attempt: "
-                                     << attempt << ", writer sequence: " << pub.message_count();
+                                     << attempt << ", writer sequence: " << writer.message_count();
         }
         continue;
+    }
+  }
+}
+
+template <size_t L, uint16_t M>
+auto run_writer_loop_zero_copy(lshl::demux::core::DemuxWriter<L, M, false>& writer, const uint64_t msg_num) noexcept(
+    false
+) -> void {
+  BOOST_LOG_TRIVIAL(info) << "sending " << msg_num << " md updates ...";
+
+  MarketDataUpdateGenerator md_gen{};
+  XXH64_util hash{};
+
+  for (uint64_t i = 1; i <= msg_num; ++i) {
+    const bool ok = write_zero_copy_(&writer, &md_gen, &hash);
+    if (!ok) {
+      BOOST_LOG_TRIVIAL(error) << "dropped one message, could not write";
+      continue;
+    }
+    if (i % REPORT_PROGRESS == 0) {
+      BOOST_LOG_TRIVIAL(info) << "number of messages sent: " << i;
+    }
+  }
+
+  BOOST_LOG_TRIVIAL(info) << "writer sequence number: " << writer.message_count()
+                          << ", XXH64_hash: " << XXH64_util::format(hash.digest());
+}
+
+template <size_t L, uint16_t M>
+[[nodiscard]] inline auto
+write_zero_copy_(DemuxWriter<L, M, false>* writer, MarketDataUpdateGenerator* md_gen, XXH64_util* hash) noexcept(false
+) -> bool {
+  for (int attempt = 0;; ++attempt) {
+    const std::optional<MarketDataUpdate*> mo = writer->template allocate<MarketDataUpdate>();
+    if (mo.has_value()) {
+      MarketDataUpdate* md = mo.value();
+#ifndef NDEBUG
+      BOOST_LOG_TRIVIAL(debug) << md;
+#endif
+      md_gen->generate_market_data_update(md);
+      writer->template commit<MarketDataUpdate>();
+      hash->update(md, sizeof(MarketDataUpdate));
+      return true;
+    } else {
+      attempt += 1;
+      if (attempt % REPORT_PROGRESS == 0) {
+        BOOST_LOG_TRIVIAL(warning) << "one or more readers are lagging, wraparound is blocked, write attempt: "
+                                   << attempt << ", writer sequence: " << writer->message_count();
+      }
     }
   }
 }
@@ -267,25 +327,25 @@ auto start_reader(const uint8_t reader_num, const uint64_t msg_num) noexcept(fal
 
   const ReaderId id{reader_num};
 
-  lshl::demux::core::DemuxReader<L, M> sub(id, span{*buffer}, message_count_sync, wraparound_sync);
+  lshl::demux::core::DemuxReader<L, M> reader(id, span{*buffer}, message_count_sync, wraparound_sync);
   BOOST_LOG_TRIVIAL(info) << "DemuxReader created, segment1.free_memory: " << segment2.get_free_memory()
                           << ", segment2.free_memory: " << segment2.get_free_memory();
 
   startup_sync->fetch_or(id.mask());
 
-  run_reader_loop(sub, msg_num);
+  run_reader_loop(reader, msg_num);
   BOOST_LOG_TRIVIAL(info) << "DemuxReader completed, segment1.free_memory: " << segment2.get_free_memory()
                           << ", segment2.free_memory: " << segment2.get_free_memory();
 }
 
 template <size_t L, uint16_t M>
-auto run_reader_loop(lshl::demux::core::DemuxReader<L, M>& sub, const uint64_t msg_num) noexcept(false) -> void {
+auto run_reader_loop(lshl::demux::core::DemuxReader<L, M>& reader, const uint64_t msg_num) noexcept(false) -> void {
   XXH64_util hash{};
   HDR_histogram_util histogram{};
 
   // consume the expected number of messages
   for (uint64_t i = 0; i < msg_num;) {
-    const std::optional<const MarketDataUpdate*> read = sub.template next_unsafe<MarketDataUpdate>();
+    const std::optional<const MarketDataUpdate*> read = reader.template next_unsafe<MarketDataUpdate>();
     if (read.has_value()) {
       i += 1;
       const MarketDataUpdate* md = read.value();
@@ -303,14 +363,14 @@ auto run_reader_loop(lshl::demux::core::DemuxReader<L, M>& sub, const uint64_t m
     }
   }
 
-  BOOST_LOG_TRIVIAL(info) << "reader sequence number: " << sub.message_count()
+  BOOST_LOG_TRIVIAL(info) << "reader sequence number: " << reader.message_count()
                           << ", XXH64_hash: " << XXH64_util::format(hash.digest());
 
   BOOST_LOG_TRIVIAL(info) << "message latency, ns:";
   histogram.print_report();
 }
 
-auto calculate_latency(const uint64_t x0) -> int64_t {
+auto inline calculate_latency(const uint64_t x0) -> int64_t {
   const std::chrono::time_point<std::chrono::steady_clock, std::chrono::nanoseconds> now =
       std::chrono::steady_clock::now();
   const uint64_t x1 = static_cast<uint64_t>(now.time_since_epoch().count());

--- a/src/demux/example/shm_demux.cpp
+++ b/src/demux/example/shm_demux.cpp
@@ -218,7 +218,7 @@ template <class T, size_t L, uint16_t M>
 [[nodiscard]] inline auto send_(DemuxWriter<L, M, false>& pub, const T& md) noexcept -> bool {
   int attempt = 0;
   while (true) {
-    const WriteResult result = pub.write_object(md);
+    const WriteResult result = pub.write_safe(md);
     switch (result) {
       case WriteResult::Success:
         return true;
@@ -285,7 +285,7 @@ auto run_reader_loop(lshl::demux::core::DemuxReader<L, M>& sub, const uint64_t m
 
   // consume the expected number of messages
   for (uint64_t i = 0; i < msg_num;) {
-    const std::optional<const MarketDataUpdate*> read = sub.template next_object<MarketDataUpdate>();
+    const std::optional<const MarketDataUpdate*> read = sub.template next_unsafe<MarketDataUpdate>();
     if (read.has_value()) {
       i += 1;
       const MarketDataUpdate* md = read.value();

--- a/src/demux/example/shm_demux.h
+++ b/src/demux/example/shm_demux.h
@@ -8,6 +8,8 @@
 #include <cstdint>
 #include <span>
 #include "../core/demultiplexer.h"
+#include "../util/xxhash_util.h"
+#include "./market_data.h"
 
 namespace lshl::demux::example {
 
@@ -19,21 +21,32 @@ auto init_logging() noexcept -> void;
 auto main_(std::span<char*> args) noexcept(false) -> int;
 
 template <size_t L, uint16_t M>
-auto start_writer(uint8_t total_reader_num, uint64_t msg_num) noexcept(false) -> void;
+auto start_writer(uint8_t total_reader_num, uint64_t msg_num, bool zero_copy) noexcept(false) -> void;
 
 template <size_t L, uint16_t M>
-auto run_writer_loop(lshl::demux::core::DemuxWriter<L, M, false>& pub, uint64_t msg_num) noexcept(false) -> void;
+auto run_writer_loop(lshl::demux::core::DemuxWriter<L, M, false>& writer, uint64_t msg_num) noexcept(false) -> void;
+
+template <size_t L, uint16_t M>
+auto run_writer_loop_zero_copy(lshl::demux::core::DemuxWriter<L, M, false>& writer, uint64_t msg_num) noexcept(false
+) -> void;
 
 template <class T, size_t L, uint16_t M>
-[[nodiscard]] inline auto send_(lshl::demux::core::DemuxWriter<L, M, false>& pub, const T& md) noexcept -> bool;
+[[nodiscard]] inline auto write_(lshl::demux::core::DemuxWriter<L, M, false>* writer, const T& md) noexcept -> bool;
+
+template <size_t L, uint16_t M>
+[[nodiscard]] inline auto write_zero_copy_(
+    lshl::demux::core::DemuxWriter<L, M, false>* writer,
+    MarketDataUpdateGenerator* md_gen,
+    lshl::demux::util::XXH64_util* hash
+) noexcept(false) -> bool;
 
 template <size_t L, uint16_t M>
 auto start_reader(uint8_t reader_num, uint64_t msg_num) noexcept(false) -> void;
 
 template <size_t L, uint16_t M>
-auto run_reader_loop(lshl::demux::core::DemuxReader<L, M>& sub, uint64_t msg_num) noexcept(false) -> void;
+auto run_reader_loop(lshl::demux::core::DemuxReader<L, M>& reader, uint64_t msg_num) noexcept(false) -> void;
 
-auto calculate_latency(uint64_t x0) -> int64_t;
+auto inline calculate_latency(uint64_t x0) -> int64_t;
 
 }  // namespace lshl::demux::example
 

--- a/src/demux/test/demultiplexer_allocate_test.cpp
+++ b/src/demux/test/demultiplexer_allocate_test.cpp
@@ -1,0 +1,225 @@
+// Copyright 2024 Leonid Shlyapnikov.
+// SPDX-License-Identifier: Apache-2.0
+
+// NOLINTBEGIN(readability-function-cognitive-complexity, misc-include-cleaner)
+
+#include <rapidcheck/gen/Container.h>
+#include <rapidcheck/gen/Select.h>
+#define UNIT_TEST
+#undef NDEBUG  // for assert to work in release build
+
+#include <gtest/gtest.h>
+#include <rapidcheck.h>  // NOLINT(misc-include-cleaner)
+#include <array>
+#include <atomic>
+#include <boost/log/core.hpp>         // NOLINT(misc-include-cleaner)
+#include <boost/log/expressions.hpp>  // NOLINT(misc-include-cleaner)
+#include <boost/log/trivial.hpp>
+#include <boost/serialization/strong_typedef.hpp>
+#include <boost/static_string/static_string.hpp>
+#include <cassert>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <future>
+#include <span>
+#include <tuple>
+#include <vector>
+#include "../core/demultiplexer.h"
+#include "../core/message_buffer.h"
+#include "../core/reader_id.h"
+#include "../util/tuple_util.h"
+
+constexpr std::chrono::seconds DEFAULT_WAIT(5);
+
+enum class Side : std::uint8_t { Bid, Ask };
+
+auto operator<<(std::ostream& os, const Side& x) -> std::ostream& {
+  switch (x) {
+    case Side::Bid:
+      os << "Bid";
+      break;
+    case Side::Ask:
+      os << "Ask";
+      break;
+  }
+  return os;
+}
+
+constexpr std::size_t MAX_SYMBOL_LEN = 8;
+using Symbol = boost::static_string<MAX_SYMBOL_LEN>;
+
+using MarketDataTick = std::tuple<
+    // Symbol,          // symbol
+    std::uint32_t,   // symbol ID
+    Side,            // side
+    std::uint16_t,   // price-level
+    std::uint64_t,   // exchange timestamp
+    std::uint64_t,   // price
+    std::uint32_t>;  // size
+
+// auto operator<<(std::ostream& os, const MarketDataTick& x) -> std::ostream& {
+//   os << "MarketDataTick{" << std::get<0>(x) << ", " << std::get<1>(x) << ", " << std::get<2>(x) << ", "
+//      << std::get<3>(x) << ", " << std::get<4>(x) << ", " << std::get<5>(x);
+//   return os;
+// }
+
+using lshl::demux::core::DemuxReader;
+using lshl::demux::core::DemuxWriter;
+using lshl::demux::core::ReaderId;
+using std::array;
+using std::atomic;
+using std::optional;
+using std::span;
+using std::uint16_t;
+using std::uint8_t;
+using std::vector;
+
+template <>
+struct rc::Arbitrary<Side> {
+  static auto arbitrary() -> Gen<Side> { return gen::element(Side::Ask, Side::Bid); }
+};
+
+template <>
+struct rc::Arbitrary<Symbol> {
+  static auto arbitrary() -> Gen<Symbol> {
+    const Gen<uint8_t> nums = gen::inRange(static_cast<uint8_t>('0'), static_cast<uint8_t>('9'));
+    const Gen<uint8_t> chars = gen::inRange(static_cast<uint8_t>('A'), static_cast<uint8_t>('Z'));
+    const Gen<vector<uint8_t>> symbols = gen::container<vector<uint8_t>>(MAX_SYMBOL_LEN, gen::oneOf(nums, chars));
+    return gen::map(symbols, [](const vector<uint8_t>& xs) { return Symbol{xs.begin(), xs.end()}; });
+  }
+};
+
+constexpr uint16_t M = sizeof(MarketDataTick);
+constexpr size_t L = 4 * lshl::demux::core::MessageBuffer<0>::required<MarketDataTick>();
+
+template <size_t L, uint16_t M, bool B>
+auto write_all_with_allocate(const vector<MarketDataTick>& messages, DemuxWriter<L, M, B>& writer) -> size_t {
+  using lshl::demux::util::operator<<;
+
+  size_t result = 0;
+  for (size_t i = 0; i < messages.size();) {
+    const optional<MarketDataTick*> m1_opt = writer.template allocate<MarketDataTick>();
+
+    if (m1_opt.has_value()) {
+      MarketDataTick* m1 = m1_opt.value();
+      *m1 = messages[i];
+      writer.template commit<MarketDataTick>();
+      std::cout << "written: " << *m1 << "\n";
+      i += 1;
+      result += 1;
+    } else {
+      // keep trying until the allocation succeeded or the test is timed out
+    }
+  }
+
+  return result;
+}
+
+template <size_t L, uint16_t M>
+auto read_n(const size_t message_num, DemuxReader<L, M>& reader) -> vector<MarketDataTick> {
+  using lshl::demux::util::operator<<;
+
+  vector<MarketDataTick> result;
+
+  while (result.size() < message_num) {
+    optional<const MarketDataTick*> mo = reader.template next_unsafe<MarketDataTick>();
+    if (mo.has_value()) {
+      const MarketDataTick* m0 = mo.value();
+      MarketDataTick m1 = *m0;
+      result.emplace_back(m1);
+    }
+  }
+
+  // read one more to unblock the reader, which might be waiting for the wraparound unblock
+  optional<const MarketDataTick*> m = reader.template next_unsafe<MarketDataTick>();
+  //   assert(!m.has_value());
+
+  return result;
+}
+
+template <bool Blocking>
+auto multiple_readers_read_x(const vector<MarketDataTick>& messages) -> bool {
+  using lshl::demux::util::operator<<;
+
+  if (messages.empty()) {
+    return true;
+  }
+
+  std::cout << '[';
+  for (const auto& x : messages) {
+    std::cout << x << ", ";
+  }
+  std::cout << "]\n";
+
+  constexpr uint8_t READER_NUM = 7;
+
+  const size_t message_num = messages.size();
+
+  array<uint8_t, L> buffer{};
+  atomic<uint64_t> msg_counter_sync{0};
+  atomic<uint64_t> wraparound_sync{0};
+  const uint64_t all_readers_mask = ReaderId::all_readers_mask(READER_NUM);
+
+  vector<DemuxReader<L, M>> readers{};
+  readers.reserve(READER_NUM);
+  for (uint8_t i = 1; i <= READER_NUM; ++i) {
+    const ReaderId id(i);
+    readers.emplace_back(id, span{buffer}, &msg_counter_sync, &wraparound_sync);
+  }
+
+  DemuxWriter<L, M, Blocking> writer(all_readers_mask, span{buffer}, &msg_counter_sync, &wraparound_sync);
+
+  std::future<size_t> future_writer_result =
+      std::async(std::launch::async, [&messages, &writer] { return write_all_with_allocate(messages, writer); });
+
+  vector<std::future<vector<MarketDataTick>>> future_reader_results{};
+  future_reader_results.reserve(READER_NUM);
+  for (auto& reader : readers) {
+    future_reader_results.emplace_back(std::async(std::launch::async, [message_num, &reader] {
+      return read_n(message_num, reader);
+    }));
+  }
+
+  future_writer_result.wait_for(DEFAULT_WAIT);
+  EXPECT_TRUE(future_writer_result.valid());
+  EXPECT_EQ(message_num, future_writer_result.get());
+
+  for (auto& future_reader_result : future_reader_results) {
+    future_reader_result.wait_for(DEFAULT_WAIT);
+    EXPECT_TRUE(future_reader_result.valid());
+    EXPECT_EQ(messages, future_reader_result.get());
+    if (::testing::Test::HasFailure()) {
+      return false;
+    }
+  }
+
+  return !::testing::Test::HasFailure();
+}
+
+TEST(BlockingDemuxWriterWithAllocateTest, AllocateAndCommitWithMultipleReadersReadX) {
+  rc::check(multiple_readers_read_x<true>);
+}
+
+TEST(NonBlockingDemuxWriterWithAllocateTest, AllocateAndCommitWithMultipleReadersReadX) {
+  rc::check(multiple_readers_read_x<false>);
+}
+
+TEST(SymbolGenerator, SymbolDistribution) {
+  rc::check([](const Symbol& symbol) { RC_TAG(symbol); });
+}
+
+// TEST(TupleTest, Equals) {
+//   rc::check([](const vector<MarketDataTick>& x1) {
+//     EXPECT_EQ(x1, x1);
+//     return !::testing::Test::HasFailure();
+//   });
+// }
+
+auto main(int argc, char** argv) -> int {
+  namespace logging = boost::log;
+  logging::core::get()->set_filter(logging::trivial::severity >= logging::trivial::warning);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+// NOLINTEND(readability-function-cognitive-complexity, misc-include-cleaner)

--- a/src/demux/test/demultiplexer_allocate_test.cpp
+++ b/src/demux/test/demultiplexer_allocate_test.cpp
@@ -50,8 +50,7 @@ constexpr std::size_t MAX_SYMBOL_LEN = 8;
 using Symbol = boost::static_string<MAX_SYMBOL_LEN>;
 
 using MarketDataTick = std::tuple<
-    // Symbol,          // symbol
-    std::uint32_t,   // symbol ID
+    Symbol,          // symbol
     Side,            // side
     std::uint16_t,   // price-level
     std::uint64_t,   // exchange timestamp
@@ -121,19 +120,18 @@ auto read_n(const size_t message_num, DemuxReader<L, M>& reader) -> vector<Marke
   using lshl::demux::util::operator<<;
 
   vector<MarketDataTick> result;
+  result.reserve(message_num);
 
   while (result.size() < message_num) {
-    optional<const MarketDataTick*> mo = reader.template next_unsafe<MarketDataTick>();
+    const optional<const MarketDataTick*> mo = reader.template next_unsafe<MarketDataTick>();
     if (mo.has_value()) {
-      const MarketDataTick* m0 = mo.value();
-      MarketDataTick m1 = *m0;
-      result.emplace_back(m1);
+      result.push_back(*mo.value());
     }
   }
 
   // read one more to unblock the reader, which might be waiting for the wraparound unblock
-  optional<const MarketDataTick*> m = reader.template next_unsafe<MarketDataTick>();
-  //   assert(!m.has_value());
+  const optional<const MarketDataTick*> m = reader.template next_unsafe<MarketDataTick>();
+  assert(!m.has_value());
 
   return result;
 }

--- a/src/demux/test/demultiplexer_test.cpp
+++ b/src/demux/test/demultiplexer_test.cpp
@@ -30,7 +30,7 @@
 
 namespace lshl::demux::core {
 
-const std::chrono::seconds DEFAULT_WAIT(5);  // NOLINT(cert-err58-cpp)
+constexpr std::chrono::seconds DEFAULT_WAIT(5);
 
 // NOLINTNEXTLINE(cppcoreguidelines-special-member-functions,hicpp-special-member-functions)
 BOOST_STRONG_TYPEDEF(std::vector<uint8_t>, TestMessage);

--- a/src/demux/util/hdr_histogram_util.h
+++ b/src/demux/util/hdr_histogram_util.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <stdexcept>
+#include <string>
 
 namespace lshl::demux::util {
 
@@ -15,9 +16,9 @@ struct HDR_histogram_util {
   explicit HDR_histogram_util() noexcept(false) {
     using std::int64_t;
     // initialize hdr_histogram
-    const int64_t lowest_discernible_value = 1L;          // Minimum value that can be tracked
-    const int64_t highest_trackable_value = 3600000000L;  // Maximum value to be tracked (e.g., 1 hour in microseconds)
-    const int significant_figures = 1;                    // Number of significant figures to maintain
+    const int64_t lowest_discernible_value = 1L;              // Minimum value that can be tracked
+    const int64_t highest_trackable_value = 10'000'000'000L;  // Maximum value to be tracked
+    const int significant_figures = 1;                        // Number of significant figures to maintain
 
     if (hdr_init(lowest_discernible_value, highest_trackable_value, significant_figures, &histogram_) != 0) {
       throw std::domain_error("hdr_init failed");
@@ -33,7 +34,7 @@ struct HDR_histogram_util {
 
   auto record_value(std::int64_t value) noexcept(false) -> void {
     if (!hdr_record_value(this->histogram_, value)) {
-      throw std::domain_error("hdr_record_value failed");
+      throw std::domain_error(std::string("hdr_record_value failed: ") + std::to_string(value));
     }
   }
 

--- a/src/demux/util/tuple_util.h
+++ b/src/demux/util/tuple_util.h
@@ -1,0 +1,46 @@
+#ifndef TUPLE_UTIL_H_589e1e98cc3f459892f440f01e885c4c
+#define TUPLE_UTIL_H_589e1e98cc3f459892f440f01e885c4c
+
+#include <cstddef>
+#include <iostream>
+#include <tuple>
+
+namespace lshl::demux::util {
+
+// Concept to check if a type is streamable (supports operator<<)
+template <typename T>
+concept Streamable = requires(std::ostream& os, T&& val) { os << std::forward<T>(val); };
+
+// Base case for recursive printing (Index == sizeof...(Types)) - stops recursion
+template <std::size_t Index = 0, typename... Types>
+  requires(Index == sizeof...(Types))  // Base case: no more elements to print
+auto print_tuple(std::ostream& /*unused*/, const std::tuple<Types...>& /*unused*/) -> void {
+  // Do nothing, recursion stops here
+}
+
+// Helper function to print the tuple recursively
+template <std::size_t Index = 0, typename... Types>
+  requires(Index < sizeof...(Types))  // Ensures this is called recursively while Index < sizeof...(Types)
+auto print_tuple(std::ostream& os, const std::tuple<Types...>& t) -> void {
+  if constexpr (Index > 0) {
+    os << ", ";
+  }
+  os << std::get<Index>(t);       // Print the element at the current index
+  print_tuple<Index + 1>(os, t);  // Recursive call to print the next element
+}
+
+// Overload operator<< for std::tuple
+template <typename... Types>
+  requires(requires(std::ostream& os, const std::tuple<Types...>& t) {
+            print_tuple(os, t);  // Ensure we can print the tuple
+          })
+auto operator<<(std::ostream& os, const std::tuple<Types...>& t) -> std::ostream& {
+  os << "(";
+  print_tuple(os, t);  // Call the recursive helper function to print the tuple elements
+  os << ")";
+  return os;
+}
+
+}  // namespace lshl::demux::util
+
+#endif  // TUPLE_UTIL_H_589e1e98cc3f459892f440f01e885c4c


### PR DESCRIPTION
## TODO
- [x] check if `next_unsafe` needs a `commit` similar to `allocate`. This is to avoid writer overriding a value that reader is still using. [Circular Buffer Wraparound](/lshlyapnikov/demux-cpp/blob/main/doc/adr/ADR003.md) should prevent this.
- [x] implement a slow reader test for both `next` and `next_unsafe` to make sure a writer does not accidentally override a message that is still used/referenced by a reader.
- [x] run profiler on zero-copy shm_demux writer to assess performance.

Closes: #12 (as part of this bigger change).